### PR TITLE
Version 1.1.15 applied to the const

### DIFF
--- a/modules/workspaces/version.go
+++ b/modules/workspaces/version.go
@@ -2,4 +2,4 @@ package workspaces
 
 // Do not change the structure of this versioning.
 // a 'v' will be prefixed for go packages
-var FIREBACK_VERSION = "1.1.14"
+var FIREBACK_VERSION = "1.1.15"


### PR DESCRIPTION
Updates the version to 1.1.15.

Version 1.1.14 could not be put in go pkg.