### PR TITLE
Hotfix for the module resolution in 18, fixed the tests

### DIFF
--- a/clients/fireback-tools-vs-code-extension/package.json
+++ b/clients/fireback-tools-vs-code-extension/package.json
@@ -2,9 +2,9 @@
   "name": "fireback-tools",
   "displayName": "Fireback Tools",
   "description": "Fireback tools and auto completion for Module3",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "engines": {
-    "vscode": "^1.89.0"
+    "vscode": "^1.75.0"
   },
   "categories": [
     "Other"

--- a/cmd/fireback/fireback-deb.sh
+++ b/cmd/fireback/fireback-deb.sh
@@ -3,7 +3,7 @@
 # Define variables
 DIRNAME="../../artifacts/fireback-server-all/"
 PACKAGE_NAME="fireback"
-PACKAGE_VERSION="1.1.18"
+PACKAGE_VERSION="1.1.19"
 DESCRIPTION="Fireback ultimate golang framework"
 MAINTAINER="Ali Torabi <ali-torabian@outlook.com>"
 BIN_PATH_AMD="../../artifacts/fireback-server-all/fireback" # Change this to the actual path of your amd64 binary

--- a/cmd/fireback/msi/Product.wxs
+++ b/cmd/fireback/msi/Product.wxs
@@ -5,7 +5,7 @@
     Language="1033"
     Manufacturer="Ali Torabi"
     Name="Fireback"
-    Version="1.1.18">
+    Version="1.1.19">
 
     <Package InstallScope="perMachine" Compressed="yes" />
 

--- a/modules/workspaces/cli-code-gen-tools.go
+++ b/modules/workspaces/cli-code-gen-tools.go
@@ -129,7 +129,7 @@ func GenContextFromCli(c *cli.Context, cat CodeGenCatalog) *CodeGenContext {
 		tsx.IncludeStaticNavigation = false
 	}
 
-	GofModuleName := "github.com/torabian/fireback"
+	GofModuleName := "github.com/torabian/fireback/modules"
 
 	if c.String("gof-module") != "" {
 		GofModuleName = c.String("gof-module")

--- a/modules/workspaces/cli.go
+++ b/modules/workspaces/cli.go
@@ -334,13 +334,18 @@ func TranslateIError(err *IError, translateDictionary map[string]map[string]stri
 
 func HandleActionInCli(c *cli.Context, result any, err *IError, t map[string]map[string]string) {
 	f := CommonCliQueryDSLBuilder(c)
-	err2 := err.ToPublicEndUser(&f)
 	if result != nil {
 		body, _ := yaml.Marshal(result)
 		fmt.Println(string(body))
 	}
 
-	if err2 != nil {
+	if err != nil {
+		err2 := err.ToPublicEndUser(&f)
+
+		if err2 == nil {
+			log.Panicln("Panic on handle action, without public error: %w", err)
+			return
+		}
 
 		fmt.Println("Error HttpCode:", err2.HttpCode)
 		fmt.Println("Error Message:", err2.Message, err.MessageTranslated)
@@ -350,7 +355,7 @@ func HandleActionInCli(c *cli.Context, result any, err *IError, t map[string]map
 				// errItem.MessageTranslated,
 			)
 		}
-		os.Exit(-1)
+		os.Exit(int(err2.HttpCode))
 	}
 
 }

--- a/modules/workspaces/codegen/firebackgo/GoEntity.tpl
+++ b/modules/workspaces/codegen/firebackgo/GoEntity.tpl
@@ -25,7 +25,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 
     {{ if or (.e.Cte) (.e.Queries) }}
-    queries "{{ .gofModule }}/modules/{{ .m.Path }}/queries"
+    queries "{{ .gofModule }}/{{ .m.Path }}/queries"
     {{ end }}
 
 	"embed"
@@ -33,13 +33,13 @@ import (
 
 	"github.com/urfave/cli"
 	{{ if .hasSeeders }}
-	seeders "{{ .gofModule }}/modules/{{ .m.Path }}/seeders/{{ .e.Upper }}"
+	seeders "{{ .gofModule }}/{{ .m.Path }}/seeders/{{ .e.Upper }}"
 	{{ end }}
 	{{ if .hasMocks }}
-	mocks "{{ .gofModule }}/modules/{{ .m.Path }}/mocks/{{ .e.Upper }}"
+	mocks "{{ .gofModule }}/{{ .m.Path }}/mocks/{{ .e.Upper }}"
 	{{ end }}
 	{{ if .hasMetas }}
-	metas "{{ .gofModule }}/modules/{{ .m.Path }}/metas"
+	metas "{{ .gofModule }}/{{ .m.Path }}/metas"
 	{{ end }}
    
 )

--- a/modules/workspaces/module3Def.go
+++ b/modules/workspaces/module3Def.go
@@ -67,6 +67,7 @@ type Module2Field struct {
 	Unsafe              bool                 `yaml:"unsafe,omitempty" json:"unsafe,omitempty"`
 	AllowCreate         bool                 `yaml:"allowCreate,omitempty" json:"allowCreate,omitempty"`
 	Module              string               `yaml:"module,omitempty" json:"module,omitempty"`
+	Provider            string               `yaml:"provider,omitempty" json:"provider,omitempty"`
 	Json                string               `yaml:"json,omitempty" json:"json,omitempty"`
 	OfType              []*Module2FieldOf    `yaml:"of,omitempty" json:"of,omitempty"`
 	Yaml                string               `yaml:"yaml,omitempty" json:"yaml,omitempty"`


### PR DESCRIPTION
- Cli actions were broken (still worked, but printing error)
- New `provided` tag added to the fields. Solves the issue for child project for importing dependencies.
- Reduced the vscode version to make it more compatible.


